### PR TITLE
Responsive card sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="es">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1.5">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Player Card 3D</title>
   <link rel="stylesheet" href="style.css">
 </head>

--- a/style.css
+++ b/style.css
@@ -8,13 +8,18 @@ body{
   background:#D8F111;
   font-family:sans-serif;
 }
-.scene{perspective:1000px}
+.scene{
+  perspective:1000px;
+  width:100%;
+  max-width:480px;
+}
 
 /* --- card base --- */
 .card{
   position:relative;
-  width:480px;          /* tu tamaño */
-  height:830px;
+  width:100%;
+  max-width:480px;
+  aspect-ratio:480/830;
   transform-style:preserve-3d;
   transition:transform .4s ease-out;
   overflow:hidden;      /* recorte */


### PR DESCRIPTION
## Summary
- allow card to scale down by making scene and card width responsive
- set meta viewport scale to 1 for better embedding

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867f4e23a18832f91c422c9085f6d9f