### PR TITLE
Add card flip interaction

### DIFF
--- a/card.js
+++ b/card.js
@@ -7,6 +7,7 @@
   const maxRot = 10;        // deg
   const maxPar = 8;         // px parallax
   let rect, rx=0, ry=0, px=0, py=0, ticking=false;
+  let isFlipped = false;
 
   /* helpers ----------------------------------------------------- */
   const clamp = (v,min,max)=>Math.min(Math.max(v,min),max);
@@ -18,10 +19,11 @@
   };
 
   const update = () => {
+    const base = isFlipped ? 180 : 0;
     /* apply rotation */
-    card.style.transform = `rotateX(${rx}deg) rotateY(${ry}deg)`;
+    card.style.transform = `rotateX(${rx}deg) rotateY(${ry + base}deg)`;
     /* parallax (art > bg) */
-    bg .style.transform = `translateZ(0)      translate(${px/2}px,${py/2}px)`;
+    bg.style.transform  = `translateZ(0)      translate(${px/2}px,${py/2}px)`;
     art.style.transform = `translateZ(30px)   translate(${px}px,${py}px)`;
     ticking = false;
   };
@@ -61,11 +63,11 @@
   const onLeave = () => {
     card.classList.add('is-out');
     card.style.transition = 'transform .4s ease-out';
-    bg .style.transition  = art.style.transition = 'transform .4s ease-out';
+    bg.style.transition  = art.style.transition = 'transform .4s ease-out';
     /* reset */
     rx = ry = px = py = 0;
-    card.style.transform = '';
-    bg .style.transform  = '';
+    card.style.transform = isFlipped ? 'rotateY(180deg)' : '';
+    bg.style.transform  = '';
     art.style.transform  = '';
   };
 
@@ -76,6 +78,10 @@
   card.addEventListener('touchstart',   onEnter, {passive:true});
   card.addEventListener('touchmove',    throttle(onMove, 16), {passive:true});
   card.addEventListener('touchend',     onLeave);
+  card.addEventListener('click', () => {
+    isFlipped = !isFlipped;
+    update();
+  });
 
   /* simple throttle (ms) */
   function throttle(fn, limit){

--- a/index.html
+++ b/index.html
@@ -9,8 +9,13 @@
 <body>
   <div class="scene">
     <div class="card" id="card">
-      <img src="assets/player-card-bg.png"   alt="background" class="layer bg">
-      <img src="assets/player-card.png" alt="artwork"    class="layer art">
+      <div class="face front">
+        <img src="assets/player-card-bg.png" alt="background" class="layer bg">
+        <img src="assets/player-card.png"    alt="artwork"    class="layer art">
+      </div>
+      <div class="face back">
+        <div class="back-content">Parte trasera</div>
+      </div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -24,8 +24,26 @@ body{
   transition:transform .4s ease-out;
   overflow:hidden;      /* recorte */
   border-radius:10px;   /* mismo radio que el marco */
-  --sx:.5;              /* custom props para sheen */
-  --sy:.5;
+}
+
+.card.is-flipped{transform:rotateY(180deg)}
+
+.face{
+  position:absolute;
+  inset:0;
+  transform-style:preserve-3d;
+  backface-visibility:hidden;
+}
+
+.front{--sx:.5;--sy:.5;}
+.back{
+  transform:rotateY(180deg);
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  background:#111;
+  color:#fff;
+  font-size:2rem;
 }
 
 /* --- layers --- */
@@ -46,7 +64,7 @@ body{
 .art {transform:translateZ(30px)}  /* parallax extra */
 
 /* --- sheen / holo --- */
-.card::after{
+.front::after{
   content:'';
   position:absolute;inset:0;
   background:linear-gradient(
@@ -66,4 +84,4 @@ body{
 }
 
 /* fade cuando sale el puntero */
-.card.is-out::after{opacity:0}
+.card.is-out .front::after{opacity:0}


### PR DESCRIPTION
## Summary
- restructure card markup to include front/back faces
- style card faces and sheen effect for flipping
- update JS to toggle flip on click and maintain pointer rotation

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68685e3e0918832fa3c64f0c8196234e